### PR TITLE
Adds media url options for sending MMS with Twilio

### DIFF
--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -63,7 +63,7 @@ module Textris
         :args       => @args,
         :content    => options[:body].is_a?(String) ? options[:body] : nil,
         :renderer   => self,
-        :media_url  => options[:media_url])
+        :media_urls => options[:media_urls])
 
       ::Textris::Message.new(options)
     end

--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -58,11 +58,12 @@ module Textris
 
       options = self.class.with_defaults(options)
       options.merge!(
-        :texter   => self.class,
-        :action   => @action,
-        :args     => @args,
-        :content  => options[:body].is_a?(String) ? options[:body] : nil,
-        :renderer => self)
+        :texter     => self.class,
+        :action     => @action,
+        :args       => @args,
+        :content    => options[:body].is_a?(String) ? options[:body] : nil,
+        :renderer   => self,
+        :media_url  => options[:media_url])
 
       ::Textris::Message.new(options)
     end

--- a/lib/textris/delivery/log.rb
+++ b/lib/textris/delivery/log.rb
@@ -11,6 +11,11 @@ module Textris
         log :debug, "From: #{message.from || 'unknown'}"
         log :debug, "To: #{message.to.map { |i| Phony.format(to) }.join(', ')}"
         log :debug, "Content: #{message.content}"
+        (message.media_urls || []).each_with_index do |media_url, index|
+          logged_message = index == 0 ? "Media URLs: " : "            "
+          logged_message << media_url
+          log :debug, logged_message
+        end
       end
 
       private

--- a/lib/textris/delivery/mail.rb
+++ b/lib/textris/delivery/mail.rb
@@ -61,6 +61,8 @@ module Textris
           get_rails_variable(key)
         when 'texter', 'action', 'from_name', 'from_phone', 'content'
           message.send(key)
+        when 'media_urls'
+          message.media_urls.join(', ')
         else
           variables[key.to_sym]
         end.to_s.strip

--- a/lib/textris/delivery/test.rb
+++ b/lib/textris/delivery/test.rb
@@ -14,7 +14,8 @@ module Textris
           :from_phone => message.from_phone,
           :texter     => message.texter,
           :action     => message.action,
-          :to         => to))
+          :to         => to,
+          :media_urls => message.media_urls))
       end
     end
   end

--- a/lib/textris/delivery/twilio.rb
+++ b/lib/textris/delivery/twilio.rb
@@ -2,10 +2,15 @@ module Textris
   module Delivery
     class Twilio < Textris::Delivery::Base
       def deliver(to)
-        client.messages.create(
+        options = {
           :from => phone_with_plus(message.from_phone),
           :to   => phone_with_plus(to),
-          :body => message.content)
+          :body => message.content
+        }
+        if message.media_url.is_a?(String) || message.media_url.is_a?(Array)
+          options[:media_url] = message.media_url
+        end
+        client.messages.create(options)
       end
 
       private

--- a/lib/textris/delivery/twilio.rb
+++ b/lib/textris/delivery/twilio.rb
@@ -7,8 +7,8 @@ module Textris
           :to   => phone_with_plus(to),
           :body => message.content
         }
-        if message.media_url.is_a?(String) || message.media_url.is_a?(Array)
-          options[:media_url] = message.media_url
+        if message.media_urls.is_a?(Array)
+          options[:media_url] = message.media_urls
         end
         client.messages.create(options)
       end

--- a/lib/textris/message.rb
+++ b/lib/textris/message.rb
@@ -1,7 +1,7 @@
 module Textris
   class Message
     attr_reader :content, :from_name, :from_phone, :to, :texter, :action, :args,
-      :media_url
+      :media_urls
 
     def initialize(options = {})
       initialize_content(options)
@@ -11,7 +11,7 @@ module Textris
       @texter     = options[:texter]
       @action     = options[:action]
       @args       = options[:args]
-      @media_url  = options[:media_url]
+      @media_urls = options[:media_urls]
     end
 
     def deliver

--- a/lib/textris/message.rb
+++ b/lib/textris/message.rb
@@ -1,15 +1,17 @@
 module Textris
   class Message
-    attr_reader :content, :from_name, :from_phone, :to, :texter, :action, :args
+    attr_reader :content, :from_name, :from_phone, :to, :texter, :action, :args,
+      :media_url
 
     def initialize(options = {})
       initialize_content(options)
       initialize_author(options)
       initialize_recipients(options)
 
-      @texter = options[:texter]
-      @action = options[:action]
-      @args   = options[:args]
+      @texter     = options[:texter]
+      @action     = options[:action]
+      @args       = options[:args]
+      @media_url  = options[:media_url]
     end
 
     def deliver

--- a/spec/textris/delivery/log_spec.rb
+++ b/spec/textris/delivery/log_spec.rb
@@ -130,4 +130,23 @@ describe Textris::Delivery::Log do
       expect(logger.log).to include "Texter: MyClass#my_action"
     end
   end
+
+  context "message with media urls" do
+    let(:message) do
+      Textris::Message.new(
+        :from    => 'Mr Jones <+48 555 666 777>',
+        :to      => ['+48 600 700 800', '48100200300'],
+        :content => 'Some text',
+        :media_urls => [
+          "http://example.com/hilarious.gif",
+          "http://example.org/serious.gif"])
+    end
+
+    it 'prints all the media URLs' do
+      delivery.deliver_to_all
+
+      expect(logger.log).to include "Media URLs: http://example.com/hilarious.gif"
+      expect(logger.log).to include "            http://example.org/serious.gif"
+    end
+  end
 end

--- a/spec/textris/delivery/mail_spec.rb
+++ b/spec/textris/delivery/mail_spec.rb
@@ -1,11 +1,12 @@
 describe Textris::Delivery::Mail do
   let(:message) do
     Textris::Message.new(
-      :from    => 'Mr Jones <+48 555 666 777>',
-      :to      => ['+48 600 700 800', '+48 100 200 300'],
-      :content => 'Some text',
-      :texter  => 'Namespace::MyCuteTexter',
-      :action  => 'my_action')
+      :from       => 'Mr Jones <+48 555 666 777>',
+      :to         => ['+48 600 700 800', '+48 100 200 300'],
+      :content    => 'Some text',
+      :texter     => 'Namespace::MyCuteTexter',
+      :action     => 'my_action',
+      :media_urls => ['http://example.com/hilarious.gif', 'http://example.org/serious.gif'])
   end
 
   let(:delivery) { Textris::Delivery::Mail.new(message) }
@@ -94,7 +95,7 @@ describe Textris::Delivery::Mail do
 
   it 'applies all template interpolations properly' do
     interpolations = %w{app env texter action from_name
-      from_phone to_phone content}
+      from_phone to_phone content media_urls}
 
     Rails.application.config = OpenStruct.new(
       :textris_mail_to_template => interpolations.map { |i| "%{#{i}}" }.join('-'))
@@ -102,7 +103,7 @@ describe Textris::Delivery::Mail do
     delivery.deliver_to_all
 
     expect(FakeMail.deliveries.last[:to].split('-')).to eq([
-      'MyAppName', 'test', 'MyCute', 'my_action', 'Mr Jones', '48555666777', '48100200300', 'Some text'])
+      'MyAppName', 'test', 'MyCute', 'my_action', 'Mr Jones', '48555666777', '48100200300', 'Some text', 'http://example.com/hilarious.gif, http://example.org/serious.gif'])
   end
 
   it 'applies all template interpolation modifiers properly' do

--- a/spec/textris/delivery/test_spec.rb
+++ b/spec/textris/delivery/test_spec.rb
@@ -1,8 +1,9 @@
 describe Textris::Delivery::Test do
   let(:message) do
     Textris::Message.new(
-      :to      => ['+48 600 700 800', '+48 100 200 300'],
-      :content => 'Some text')
+      :to         => ['+48 600 700 800', '+48 100 200 300'],
+      :content    => 'Some text',
+      :media_urls => ["http://example.com/hilarious.gif"])
   end
 
   let(:delivery) { Textris::Delivery::Test.new(message) }
@@ -11,7 +12,7 @@ describe Textris::Delivery::Test do
     expect(delivery).to respond_to(:deliver_to_all)
   end
 
-  it 'adds proper delievries to deliveries array' do
+  it 'adds proper deliveries to deliveries array' do
     delivery.deliver_to_all
 
     expect(Textris::Delivery::Test.deliveries.count).to eq 2
@@ -25,6 +26,7 @@ describe Textris::Delivery::Test do
     expect(last_message.texter).to eq message.texter
     expect(last_message.action).to eq message.action
     expect(last_message.to[0]).to eq message.to[1]
+    expect(last_message.media_urls[0]).to eq message.media_urls[0]
   end
 
   it 'allows clearing messages array' do

--- a/spec/textris/delivery/twilio_spec.rb
+++ b/spec/textris/delivery/twilio_spec.rb
@@ -1,11 +1,4 @@
 describe Textris::Delivery::Twilio do
-  let(:message) do
-    Textris::Message.new(
-      :to      => ['+48 600 700 800', '+48 100 200 300'],
-      :content => 'Some text')
-  end
-
-  let(:delivery) { Textris::Delivery::Twilio.new(message) }
 
   before do
     class MessageArray
@@ -26,16 +19,73 @@ describe Textris::Delivery::Twilio do
     end
   end
 
-  it 'responds to :deliver_to_all' do
-    expect(delivery).to respond_to(:deliver_to_all)
-  end
-
-  it 'invokes Twilio REST client for each recipient' do
-    expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
-      expect(msg).to have_key(:to)
-      expect(msg).to have_key(:body)
+  describe "sending multiple messages" do
+    let(:message) do
+      Textris::Message.new(
+        :to         => ['+48 600 700 800', '+48 100 200 300'],
+        :content    => 'Some text')
     end
 
-    delivery.deliver_to_all
+    let(:delivery) { Textris::Delivery::Twilio.new(message) }
+
+    it 'responds to :deliver_to_all' do
+      expect(delivery).to respond_to(:deliver_to_all)
+    end
+
+    it 'invokes Twilio REST client for each recipient' do
+      expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
+        expect(msg).to have_key(:to)
+        expect(msg).to have_key(:body)
+        expect(msg).not_to have_key(:media_url)
+        expect(msg[:body]).to eq(message.content)
+      end
+
+      delivery.deliver_to_all
+    end
+  end
+
+  describe "sending media messages" do
+
+    describe "sending a single media url" do
+      let(:message) do
+        Textris::Message.new(
+          :to         => ['+48 600 700 800', '+48 100 200 300'],
+          :content    => 'Some text',
+          :media_url  => 'http://example.com/boo.gif')
+      end
+
+      let(:delivery) { Textris::Delivery::Twilio.new(message) }
+
+      it 'invokes Twilio REST client for each recipient' do
+        expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
+          expect(msg).to have_key(:media_url)
+          expect(msg[:media_url]).to eq(message.media_url)
+        end
+
+        delivery.deliver_to_all
+      end
+    end
+
+    describe "sending multiple media urls" do
+      let(:message) do
+        Textris::Message.new(
+          :to         => ['+48 600 700 800', '+48 100 200 300'],
+          :content    => 'Some text',
+          :media_url  => [
+            'http://example.com/boo.gif',
+            'http://example.com/yay.gif'])
+      end
+
+      let(:delivery) { Textris::Delivery::Twilio.new(message) }
+
+      it 'invokes Twilio REST client for each recipient' do
+        expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
+          expect(msg).to have_key(:media_url)
+          expect(msg[:media_url]).to eq(message.media_url)
+        end
+
+        delivery.deliver_to_all
+      end
+    end
   end
 end

--- a/spec/textris/delivery/twilio_spec.rb
+++ b/spec/textris/delivery/twilio_spec.rb
@@ -45,47 +45,24 @@ describe Textris::Delivery::Twilio do
   end
 
   describe "sending media messages" do
-
-    describe "sending a single media url" do
-      let(:message) do
-        Textris::Message.new(
-          :to         => ['+48 600 700 800', '+48 100 200 300'],
-          :content    => 'Some text',
-          :media_url  => 'http://example.com/boo.gif')
-      end
-
-      let(:delivery) { Textris::Delivery::Twilio.new(message) }
-
-      it 'invokes Twilio REST client for each recipient' do
-        expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
-          expect(msg).to have_key(:media_url)
-          expect(msg[:media_url]).to eq(message.media_url)
-        end
-
-        delivery.deliver_to_all
-      end
+    let(:message) do
+      Textris::Message.new(
+        :to         => ['+48 600 700 800', '+48 100 200 300'],
+        :content    => 'Some text',
+        :media_urls => [
+          'http://example.com/boo.gif',
+          'http://example.com/yay.gif'])
     end
 
-    describe "sending multiple media urls" do
-      let(:message) do
-        Textris::Message.new(
-          :to         => ['+48 600 700 800', '+48 100 200 300'],
-          :content    => 'Some text',
-          :media_url  => [
-            'http://example.com/boo.gif',
-            'http://example.com/yay.gif'])
+    let(:delivery) { Textris::Delivery::Twilio.new(message) }
+
+    it 'invokes Twilio REST client for each recipient' do
+      expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
+        expect(msg).to have_key(:media_url)
+        expect(msg[:media_url]).to eq(message.media_urls)
       end
 
-      let(:delivery) { Textris::Delivery::Twilio.new(message) }
-
-      it 'invokes Twilio REST client for each recipient' do
-        expect_any_instance_of(MessageArray).to receive(:create).twice do |context, msg|
-          expect(msg).to have_key(:media_url)
-          expect(msg[:media_url]).to eq(message.media_url)
-        end
-
-        delivery.deliver_to_all
-      end
+      delivery.deliver_to_all
     end
   end
 end


### PR DESCRIPTION
You can send up to 10 images using the [`media_url` option in Twilio](http://twilio-ruby.readthedocs.io/en/latest/usage/messages.html#sending-a-picture-message). This implements `media_url` for the `Message` class and uses it within the Twilio delivery class.

Let me know what you think and if I should add this somehow to the mail or log delivery classes too.