### PR TITLE
Removes setting media_urls on Textris::Base.

### DIFF
--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -62,8 +62,7 @@ module Textris
         :action     => @action,
         :args       => @args,
         :content    => options[:body].is_a?(String) ? options[:body] : nil,
-        :renderer   => self,
-        :media_urls => options[:media_urls])
+        :renderer   => self)
 
       ::Textris::Message.new(options)
     end


### PR DESCRIPTION
I didn't notice that the options were already merged using `with_defaults` above. So this line is unnecessary.