### PR TITLE
Initial support for sending SMS from short codes

### DIFF
--- a/lib/textris.rb
+++ b/lib/textris.rb
@@ -22,6 +22,7 @@ else
 end
 
 require 'textris/base'
+require 'textris/utils'
 require 'textris/message'
 
 begin

--- a/lib/textris/delivery/twilio.rb
+++ b/lib/textris/delivery/twilio.rb
@@ -1,6 +1,10 @@
+require 'textris/utils'
+
 module Textris
   module Delivery
     class Twilio < Textris::Delivery::Base
+      include Textris::Utils
+
       def deliver(to)
         options = {
           :from => phone_with_plus(message.from_phone),
@@ -17,6 +21,7 @@ module Textris
 
       # Twillo requires phone numbers starting with a '+' sign
       def phone_with_plus(phone)
+        return phone if is_short_code?(phone)
         phone.to_s.start_with?('+') ? phone : "+#{phone}"
       end
 

--- a/lib/textris/message.rb
+++ b/lib/textris/message.rb
@@ -1,5 +1,9 @@
+require 'textris/utils'
+
 module Textris
   class Message
+    include Textris::Utils
+
     attr_reader :content, :from_name, :from_phone, :to, :texter, :action, :args,
       :media_urls
 
@@ -82,7 +86,7 @@ module Textris
 
     def parse_from_dual(from)
       if (matches = from.to_s.match(/(.*)\<(.*)\>\s*$/).to_a).size == 3 &&
-          Phony.plausible?(matches[2])
+          (Phony.plausible?(matches[2]) || is_short_code?(matches[2]))
         [matches[1].strip, Phony.normalize(matches[2])]
       end
     end
@@ -90,6 +94,8 @@ module Textris
     def parse_from_singular(from)
       if Phony.plausible?(from)
         [nil, Phony.normalize(from)]
+      elsif is_short_code?(from)
+        [nil, from.to_s]
       elsif from.present?
         [from.strip, nil]
       end

--- a/lib/textris/utils.rb
+++ b/lib/textris/utils.rb
@@ -1,0 +1,10 @@
+module Textris
+  module Utils
+    # The Phony gem doesn't handle short codes. Short codes can be 5 or 6 digits
+    # long. There are more restrictions on short codes, but this is a good
+    # general start.
+    def is_short_code?(phone_number)
+      !!phone_number.to_s.match(/\A\d{5,6}\z/)
+    end
+  end
+end

--- a/spec/textris/delivery/twilio_spec.rb
+++ b/spec/textris/delivery/twilio_spec.rb
@@ -65,4 +65,57 @@ describe Textris::Delivery::Twilio do
       delivery.deliver_to_all
     end
   end
+
+  describe "sending from short codes" do
+    it 'prepends regular phone numbers code with a +' do
+      number = '48 600 700 800'
+      message = Textris::Message.new(
+        :from       => number,
+        :content    => 'Some text',
+        :to         => '+48 100 200 300'
+      )
+      delivery = Textris::Delivery::Twilio.new(message)
+
+      expect_any_instance_of(MessageArray).to receive(:create).once do |context, msg|
+        expect(msg).to have_key(:from)
+        expect(msg[:from]).to eq("+#{number.gsub(/\s/, '')}")
+      end
+
+      delivery.deliver_to_all
+    end
+
+    it 'doesn\'t prepend a 6 digit short code with a +' do
+      number = '894546'
+      message = Textris::Message.new(
+        :from       => number,
+        :content    => 'Some text',
+        :to         => '+48 100 200 300'
+      )
+      delivery = Textris::Delivery::Twilio.new(message)
+
+      expect_any_instance_of(MessageArray).to receive(:create).once do |context, msg|
+        expect(msg).to have_key(:from)
+        expect(msg[:from]).to eq(number)
+      end
+
+      delivery.deliver_to_all
+    end
+
+    it 'doesn\'t prepend a 5 digit short code with a +' do
+      number = '44397'
+      message = Textris::Message.new(
+        :from       => number,
+        :content    => 'Some text',
+        :to         => '+48 100 200 300'
+      )
+      delivery = Textris::Delivery::Twilio.new(message)
+
+      expect_any_instance_of(MessageArray).to receive(:create).once do |context, msg|
+        expect(msg).to have_key(:from)
+        expect(msg[:from]).to eq(number)
+      end
+
+      delivery.deliver_to_all
+    end
+  end
 end

--- a/spec/textris/message_spec.rb
+++ b/spec/textris/message_spec.rb
@@ -37,6 +37,26 @@ describe Textris::Message do
         expect(message.from_name).to eq('Mr Jones')
         expect(message.from_phone).to be_nil
       end
+
+      it 'parses short codes properly' do
+        message = Textris::Message.new(
+          :content => 'X',
+          :from    => '894546',
+          :to      => '+48 111 222 444')
+
+        expect(message.from_name).to be_nil
+        expect(message.from_phone).to eq('894546')
+      end
+
+      it 'parses short codes and names properly' do
+        message = Textris::Message.new(
+          :content => 'X',
+          :from    => 'Mr Jones <894546> ',
+          :to      => '+48 111 222 444')
+
+        expect(message.from_name).to eq('Mr Jones')
+        expect(message.from_phone).to eq('894546')
+      end
     end
 
     describe 'parsing :to' do

--- a/spec/textris/utils_spec.rb
+++ b/spec/textris/utils_spec.rb
@@ -1,0 +1,26 @@
+class UtilsHarness
+  include Textris::Utils
+end
+
+describe Textris::Utils do
+  let (:util) { UtilsHarness.new }
+  it 'should recognise a 5 digit short code' do
+    expect(util.is_short_code?("44397")).to be true
+  end
+
+  it 'should recognise a 6 digit short code' do
+    expect(util.is_short_code?("894546")).to be true
+  end
+
+  it 'should not recognise 7 digits or more as a short code' do
+    ['8945467', '89454678', '894546789'].each do |number|
+      expect(util.is_short_code?(number)).to be false
+    end
+  end
+
+  it 'should not recognise 4 digits or less as a short code' do
+    ['8945', '894', '89', '8'].each do |number|
+      expect(util.is_short_code?(number)).to be false
+    end
+  end
+end


### PR DESCRIPTION
This should fix #25.

I have included an `is_short_code?` method that does a basic check on whether a number looks like a short code. In this case, that is simply whether it is a 5 or 6 digit long number. There are more restrictions on short codes than that, however this is a start and the assumption is that users would know what short code they are using along with the restrictions around it (i.e. no international messages).

I've started a `Utils` class for the `is_short_code?` method as it was needed in two places. `Utils` is not a great name but I couldn't think of anything better right now.