### PR TITLE
Nexmo deliveries can use alphanumeric "from" attribute

### DIFF
--- a/lib/textris/delivery/nexmo.rb
+++ b/lib/textris/delivery/nexmo.rb
@@ -3,7 +3,7 @@ module Textris
     class Nexmo < Textris::Delivery::Base
       def deliver(phone)
         client.send_message(
-          from: message.from_phone,
+          from: sender_id,
           to:   phone,
           text: message.content
         )
@@ -12,6 +12,10 @@ module Textris
       private
         def client
           @client ||= ::Nexmo::Client.new
+        end
+
+        def sender_id
+          message.from_phone || message.from_name
         end
     end
   end

--- a/spec/textris/delivery/nexmo_spec.rb
+++ b/spec/textris/delivery/nexmo_spec.rb
@@ -2,7 +2,8 @@ describe Textris::Delivery::Nexmo do
   let(:message) do
     Textris::Message.new(
     :to      => ['+48 600 700 800', '+48 100 200 300'],
-    :content => 'Some text')
+    :content => 'Some text',
+    :from    => 'Alpha ID')
   end
 
   let(:delivery) { Textris::Delivery::Nexmo.new(message) }
@@ -11,6 +12,7 @@ describe Textris::Delivery::Nexmo do
     module Nexmo
       class Client
         def send_message(params)
+          params
         end
       end
     end
@@ -28,5 +30,15 @@ describe Textris::Delivery::Nexmo do
     end
 
     delivery.deliver_to_all
+  end
+
+  describe '#deliver' do
+    subject { delivery.deliver('48600700800') }
+
+    context 'when from_phone is nil' do
+      it 'will use from_name' do
+        expect(subject[:from]).to eq 'Alpha ID'
+      end
+    end
   end
 end


### PR DESCRIPTION
The Nexmo API allows using an 11 character alphanumeric string for the `from` attribute (instead of a phone number). See the docs [here](https://developer.nexmo.com/api/sms) and [here](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id).

This PR modifies the Nexmo delivery method to use the `from_name` attribute if the `from_phone` is blank, so I can set up my texter like so:

```
class MyTexter < Textris::Base
  default from: 'My App'

  def send_welcome(user)
    text(to: user.phone)
  end
end
```

And have the user receive a text from 'My App'. (I believe this only works in certain countries, but it definitely works here in Australia.)