### PR TITLE
Docs: Fix Nexmo integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 In order to use Nexmo with **textris**, you need to include the `nexmo` gem in your `Gemfile`:
 
 ```ruby
-gem 'nexmo'
+gem 'nexmo', '~> 4'
 ```
 
 The Nexmo gem uses the environment variables `NEXMO_API_KEY` and `NEXMO_API_SECRET` to authenticate with the API.


### PR DESCRIPTION
In Nexmo Gem version 5.0.0, some API breaking changes appeared. Leading to this kind of error:

    NoMethodError: undefined method `send_message' for #<Nexmo::Client:0x007f848744dcd0>

In this commit, I suggest locking the major version of Nexmo Gem to 4. In the future, it would be better to fix the integration.
Useful links:

- https://github.com/Nexmo/nexmo-ruby/blob/master/CHANGES.md
- https://github.com/visualitypl/textris/blob/master/lib/textris/delivery/nexmo.rb