### PR TITLE
Define `respond_to_missing?` in base texter

### DIFF
--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -35,7 +35,11 @@ module Textris
       private
 
       def method_missing(method_name, *args)
-        self.new(method_name, *args).call_action
+        new(method_name, *args).call_action
+      end
+
+      def respond_to_missing?(method, *args)
+        public_instance_methods(true).include?(method) || super
       end
     end
 

--- a/lib/textris/version.rb
+++ b/lib/textris/version.rb
@@ -1,3 +1,3 @@
 module Textris
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/textris/base_spec.rb
+++ b/spec/textris/base_spec.rb
@@ -138,6 +138,18 @@ describe Textris::Base do
 
       expect(call_info[:calls]).to eq(1)
     end
+
+    it 'raises no method error on undefined actions' do
+      expect { MyTexter.fake_action }.to raise_error NoMethodError
+    end
+
+    it 'responds to defined actions' do
+      expect(MyTexter.respond_to?(:my_action)).to eq true
+    end
+
+    it 'does not respond to undefined actions' do
+      expect(MyTexter.respond_to?(:fake_action)).to eq false
+    end
   end
 
   describe Textris::Base::RenderingController do


### PR DESCRIPTION
Original PR at https://github.com/visualitypl/textris/pull/44

Re-created as local repo branch so new Travis environment runs properly.

Original description by @papa-whisky:

>Attempting to expect a method call to a texter in RSpec results in a failure:
```
Failure/Error:
       expect(ExampleTexter).to receive(:send_text)
       ExampleTexter does not implement: send_text
```
>This PR defines the respond_to_missing? method to remedy this, as recommended by community style guide.

