### PR TITLE
Add the ability to specify template_path

### DIFF
--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -55,32 +55,36 @@ module Textris
     def render_content
       set_instance_variables_for_rendering
 
-      render(:template => template_name, :formats => ['text'], :locale => @locale)
+      render(
+        :template => @action,
+        :template_path => @template_path,
+        :formats => ['text'],
+        :locale => @locale
+      )
     end
 
     protected
 
     def text(options = {})
       @locale = options[:locale] || I18n.locale
+      set_template_path(options)
 
       options = self.class.with_defaults(options)
       options.merge!(
-        :texter     => self.class,
-        :action     => @action,
-        :args       => @args,
-        :content    => options[:body].is_a?(String) ? options[:body] : nil,
-        :renderer   => self)
+        :texter        => self.class,
+        :action        => @action,
+        :args          => @args,
+        :content       => options[:body].is_a?(String) ? options[:body] : nil,
+        :renderer      => self)
 
       ::Textris::Message.new(options)
     end
 
     private
 
-    def template_name
-      class_name  = self.class.to_s.underscore.sub('texter/', '')
-      action_name = @action
-
-      "#{class_name}/#{action_name}"
+    def set_template_path(options)
+      template_path = options[:template_path].is_a?(String) ? options[:template_path] : nil
+      @template_path = template_path.presence || self.class.to_s.underscore.sub('texter/', '')
     end
 
     def set_instance_variables_for_rendering

--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -66,11 +66,11 @@ module Textris
 
       options = self.class.with_defaults(options)
       options.merge!(
-        :texter        => self.class,
-        :action        => @action,
-        :args          => @args,
-        :content       => options[:body].is_a?(String) ? options[:body] : nil,
-        :renderer      => self)
+        :texter     => self.class,
+        :action     => @action,
+        :args       => @args,
+        :content    => options[:body].is_a?(String) ? options[:body] : nil,
+        :renderer   => self)
 
       ::Textris::Message.new(options)
     end
@@ -81,7 +81,7 @@ module Textris
       template_path = @template_path.presence || self.class.to_s.underscore.sub('texter/', '')
       action_name = @action
 
-       "#{template_path}/#{action_name}"
+      "#{template_path}/#{action_name}"
     end
 
     def set_instance_variables_for_rendering

--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -55,19 +55,14 @@ module Textris
     def render_content
       set_instance_variables_for_rendering
 
-      render(
-        :template => @action,
-        :template_path => @template_path,
-        :formats => ['text'],
-        :locale => @locale
-      )
+      render(:template => template_name, :formats => ['text'], :locale => @locale)
     end
 
     protected
 
     def text(options = {})
       @locale = options[:locale] || I18n.locale
-      set_template_path(options)
+      @template_path = options[:template_path].is_a?(String) ? options[:template_path] : nil
 
       options = self.class.with_defaults(options)
       options.merge!(
@@ -82,9 +77,11 @@ module Textris
 
     private
 
-    def set_template_path(options)
-      template_path = options[:template_path].is_a?(String) ? options[:template_path] : nil
-      @template_path = template_path.presence || self.class.to_s.underscore.sub('texter/', '')
+    def template_name(options)
+      template_path = @template_path.presence || self.class.to_s.underscore.sub('texter/', '')
+      action_name = @action
+
+       "#{template_path}/#{action_name}"
     end
 
     def set_instance_variables_for_rendering

--- a/lib/textris/base.rb
+++ b/lib/textris/base.rb
@@ -77,7 +77,7 @@ module Textris
 
     private
 
-    def template_name(options)
+    def template_name
       template_path = @template_path.presence || self.class.to_s.underscore.sub('texter/', '')
       action_name = @action
 


### PR DESCRIPTION
Adds the ability to specify `:template_path` option to the `text` method, that will then replace the default template path when rendered

https://github.com/visualitypl/textris/issues/29