### PR TITLE
sidekiq tests broke because of time-related bug in test

### DIFF
--- a/spec/textris/delay/sidekiq_spec.rb
+++ b/spec/textris/delay/sidekiq_spec.rb
@@ -154,7 +154,9 @@ describe Textris::Delay::Sidekiq do
 
     describe '#delay_until' do
       it 'schedules action with proper params and execution time' do
-        MyTexter.delay_until(Time.new(2020, 1, 1)).delayed_action(
+        # sidekiq behaves differently if we're not queueing into the future
+        expected_scheduled_time = Time.new(Time.now.year + 1, 1, 1)
+        MyTexter.delay_until(expected_scheduled_time).delayed_action(
           '48111222333', 'Hi')
 
         expect_any_instance_of(MyTexter).to receive(:text).with(
@@ -163,7 +165,7 @@ describe Textris::Delay::Sidekiq do
 
         scheduled_at = Time.at(Textris::Delay::Sidekiq::Worker.jobs.last['at'])
 
-        expect(scheduled_at).to eq Time.new(2020, 1, 1)
+        expect(scheduled_at).to eq expected_scheduled_time
 
         Textris::Delay::Sidekiq::Worker.drain
       end


### PR DESCRIPTION
The Sidekiq test that was making sure `delay_until` was working properly was queueing at a hardcoded `2020-01-01`. 

Sidekiq doesn't treat the job as a scheduled job if the scheduled time requested is in the past. This was causing an exception in the test. 

This PR adjusts the test to always use a date in the future.