### PR TITLE
Fix delivery/twilio Ruby 3 Compatibility Issue

### DIFF
--- a/lib/textris/delivery/twilio.rb
+++ b/lib/textris/delivery/twilio.rb
@@ -17,7 +17,7 @@ module Textris
           options[:media_url] = message.media_urls
         end
 
-        client.messages.create(options)
+        client.messages.create(**options)
       end
 
       private


### PR DESCRIPTION
Fixes an issue caused by passing down a hash to a method which expects kwargs

```ruby
Failure/Error: texter.deliver_now
     
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # /lib/twilio-ruby/rest/api/v2010/account/message.rb:130:in `create'
     # lib/textris/delivery/twilio.rb:20:in `deliver'
```

Specs are not passing caused by render_anywhere compatibility issue with Rails 6, more on this here: https://github.com/visualitypl/textris/pull/55 and https://github.com/visualitypl/textris/issues/50